### PR TITLE
Fix `WordsClient` when working with Windows

### DIFF
--- a/src/BlazorWordle/Clients/WordsClient.cs
+++ b/src/BlazorWordle/Clients/WordsClient.cs
@@ -15,7 +15,7 @@ public sealed class WordsClient
         if (_words is null)
         {
             var response = await _client.GetStringAsync("assets/words.txt");
-            _words = response.Split('\n');
+            _words = response.Split(Environment.NewLine, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
         }
 
         return _words;


### PR DESCRIPTION
'\r' char wasn't being stripped, making the words 6 chars long